### PR TITLE
Cleanup `Reference` & `Chat2Adv`

### DIFF
--- a/src/main/java/gkappa/cta/Chat2Adv.java
+++ b/src/main/java/gkappa/cta/Chat2Adv.java
@@ -2,14 +2,10 @@ package gkappa.cta;
 
 
 import gkappa.cta.proxy.IProxy;
-import net.minecraft.client.gui.GuiScreen;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
-import net.minecraftforge.fml.common.Mod.Instance;
 import net.minecraftforge.fml.common.SidedProxy;
-import net.minecraftforge.fml.common.event.*;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 
 @Mod(
         modid = Reference.MOD_ID,
@@ -19,38 +15,12 @@ import org.apache.logging.log4j.Logger;
         dependencies = Reference.MOD_DEPENDENCIES
 )
 public class Chat2Adv {
-    public static final Logger LOGGER = LogManager.getLogger(Reference.MOD_ID);
-    public static GuiScreen baGui = null;
     @SidedProxy(clientSide = "gkappa.cta.proxy.ClientProxy", serverSide = "gkappa.cta.proxy.CommonProxy")
     public static IProxy proxy;
-
-	@Instance(Reference.MOD_ID)
-	public static Chat2Adv _instance;
-    public Chat2Adv() {}
         
     @EventHandler
     public static void preInit(FMLPreInitializationEvent event) {
         proxy.preInit(event);
 
-    }
-
-    @EventHandler
-    public static void init(FMLInitializationEvent event) {
-    }
-    
-    @EventHandler
-    public static void postInit(FMLPostInitializationEvent event) {
-    }
-    
-    @EventHandler
-    public void onServerStarting(FMLServerStartingEvent event) {
-    }
-
-    @EventHandler
-    public void onServerStarted(FMLServerStartedEvent event) {
-    }
-
-    @EventHandler
-    public void onServerStopping(FMLServerStoppingEvent event) {
     }
 }

--- a/src/main/java/gkappa/cta/Reference.java
+++ b/src/main/java/gkappa/cta/Reference.java
@@ -6,24 +6,9 @@ public class Reference {
 	public static final String MOD_NAME = "@MODNAME@";
     public static final String MOD_ID = "cta";
     public static final String MOD_VERSION = "@VERSION@";
-    public static final String MOD_BUILD_NUMBER = "@BUILD_NUMBER@";
-    public static final String MOD_CHANNEL = MOD_ID;
-    public static final String MOD_MC_VERSION = "@MC_VERSION@";
-    public static final String MOD_FINGERPRINT = "@FINGERPRINT@";
-
-    // Paths
-    public static final String TEXTURE_PATH_GUI = "textures/gui/";
-    public static final String TEXTURE_PATH_SKINS = "textures/skins/";
-    public static final String TEXTURE_PATH_MODELS = "textures/models/";
-    public static final String TEXTURE_PATH_ENTITIES = "textures/entities/";
-    public static final String TEXTURE_PATH_GUIBACKGROUNDS = "textures/gui/title/background/";
-    public static final String TEXTURE_PATH_ITEMS = "textures/items/";
-    public static final String TEXTURE_PATH_PARTICLES = "textures/particles/";
-    public static final String MODEL_PATH = "models/";
     
     // MOD ID's
     public static final String MOD_FORGE = "forge";
-    public static final String MOD_FORGE_VERSION = "@FORGE_VERSION@";
     public static final String MOD_FORGE_VERSION_MIN = "14.23.5.2855";
     
     // Dependencies


### PR DESCRIPTION
This cleans up two things, the reference class as most of it was unused variables from the template and the main class for the same reasons.

I was sadly not able to do further cleanup as running the client would lead to a crash (Probably due to FG5 should have perhaps cleaned my cache but the rest of the code fell already clean so did not bother).

That does mean I was not able to test this, that is why I **highly** recommend to test this, if anything goes wrong just comment here and I will fix it.