### PR TITLE
Probably fix the mod crashing the server

### DIFF
--- a/src/main/java/gkappa/cta/Chat2Adv.java
+++ b/src/main/java/gkappa/cta/Chat2Adv.java
@@ -8,6 +8,7 @@ import net.minecraftforge.fml.common.SidedProxy;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 
 @Mod(
+        clientSideOnly = true,
         modid = Reference.MOD_ID,
         name = Reference.MOD_NAME,
         useMetadata = true,


### PR DESCRIPTION
This mod crashes a server. It is untraceable. The only way to know it is the culprit is to do a binary search or know beforehand.
This should fix it; the server will just disable the mod and print a warning.